### PR TITLE
修复：处理景点资料中 description 和 address 栏位为 NaN 时导致的验证错误

### DIFF
--- a/backend_local/app/crud.py
+++ b/backend_local/app/crud.py
@@ -3,6 +3,7 @@
 import os
 import pandas as pd
 from .models import Attraction, Post
+from .utils import safe_str
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 DATA_DIR = os.path.join(BASE_DIR, "data")
@@ -48,13 +49,13 @@ def list_attractions(dest: str):
     return [
         Attraction(
             id     = r["id"],
-            name   = r["name"],
-            description = r.get("description"),
+            name   = safe_str(r["name"]),
+            description = safe_str(r.get("description")),
             lat    = r["lat"],
             lon    = r["lon"],
             tags   = r["tags"],
             images = r["images"],     # 返回图片列表
-            address= r.get("address"),# 返回地址
+            address= safe_str(r.get("address")),# 返回地址
             pros   = [],
             cons   = [],
             source_posts=[]

--- a/backend_local/app/utils.py
+++ b/backend_local/app/utils.py
@@ -1,5 +1,23 @@
-# 示例：把行程草稿转换成 GeoJSON
+from typing import List
+import math
 
+def safe_str(value):
+    """
+    将输入值安全转换为字串，处理 None 或 NaN 等非法情况。
+
+    参数:
+        value: 任意值，可能是 None、NaN 或其他类型。
+
+    返回:
+        str: 若为 NaN 或 None，回传空字串 ""；否则回传其字串形式。
+    """
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return ""
+    return str(value)
+
+
+
+# 示例：把行程草稿转换成 GeoJSON
 def to_geojson(items: List[dict]) -> dict:
     features = []
     for itm in items:


### PR DESCRIPTION
针对景点资料中 description 或 address 栏位为 NaN 或 None 时，FastAPI 回传 500 错误的问题。这些异常值会使 Pydantic 模型验证失败，导致伺服器中断。

**Before:**
当资料来源（如 CSV）中 description 或 address 栏位为 NaN 时，API 呼叫 /attractions 会直接报错。
Log:`ValidationError: Input should be a valid string (got NaN as float)`

**After:**
对 NaN 或 None 的值，会透过 safe_str() 函数自动转为空字串（””），现在运作正常

**Details:**
- 在 utils.py 中新增 safe_str() 函数，统一处理非字串（如 NaN、None）转换。
- 在 crud.py 中的 list_attractions() 函数里，针对 description, address, name 栏位加上 safe_str() 包装。
- 同时补上了 utils.py 中缺少的 List 汇入，避免启动时报错。